### PR TITLE
Add foreman Procfile

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,2 @@
+web: bundle exec rails s
+worker: bundle exec sidekiq


### PR DESCRIPTION
This is so that we can start both the server and the sidekiq process with a single `foreman start` command.
